### PR TITLE
Disable empty route

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -127,10 +127,10 @@ Route::group([
         'uses' => 'LoginController@logout',
     ]);
 
-    Route::get('__ajax/modal/settings', [
+    /* Route::get('__ajax/modal/settings', [
         'as'   => 'ajax.modal.user.settings',
         'uses' => '',
-    ]);
+    ]); */
 
     // --------------------------------------------------------------
     // ADMIN


### PR DESCRIPTION
The empty route breaks Laravel 5.2 

```
([2016-01-16 15:33:48] local.ERROR: exception 'UnexpectedValueException' with message 'Invalid route action: [ViKon\Wiki\Http\Controller\]' in wiki/vendor/laravel/framework/src/Illuminate/Routing/Route.php:539)
```
